### PR TITLE
Disable syncing from API DB to Keycloak

### DIFF
--- a/src/keycloak-sync-on-startup/keycloak-sync-on-startup/keycloak-sync-on-startup.service.spec.ts
+++ b/src/keycloak-sync-on-startup/keycloak-sync-on-startup/keycloak-sync-on-startup.service.spec.ts
@@ -92,27 +92,6 @@ describe('UsersSyncOnStartupService', () => {
         }),
         true,
       );
-
-      // Organizations
-      expect(organizationsService.findAll).toHaveBeenCalledTimes(1);
-      expect(
-        keycloakResourcesService.getGroupForOrganization,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        keycloakResourcesService.getGroupForOrganization,
-      ).toHaveBeenCalledWith(org1.id);
-      expect(keycloakResourcesService.createGroup).toHaveBeenCalledTimes(1);
-      expect(keycloakResourcesService.createGroup).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: org1.id,
-          name: org1.name,
-        }),
-      );
-
-      // User invitations
-      expect(keycloakResourcesService.inviteUserToGroup).toHaveBeenCalledTimes(
-        2,
-      );
     });
 
     it('should handle case when keycloak group exists', async () => {
@@ -133,13 +112,7 @@ describe('UsersSyncOnStartupService', () => {
       await service.sync();
 
       // Verify
-      expect(
-        keycloakResourcesService.getGroupForOrganization,
-      ).toHaveBeenCalledTimes(1);
       expect(keycloakResourcesService.createGroup).not.toHaveBeenCalled(); // Group exists, shouldn't create
-      expect(keycloakResourcesService.inviteUserToGroup).toHaveBeenCalledTimes(
-        2,
-      );
     });
 
     it('should handle error when inviting user to group', async () => {
@@ -163,12 +136,6 @@ describe('UsersSyncOnStartupService', () => {
 
       // Execute
       await service.sync();
-
-      // Verify
-      expect(keycloakResourcesService.inviteUserToGroup).toHaveBeenCalledTimes(
-        2,
-      );
-      expect(console.warn).toHaveBeenCalledTimes(2);
     });
 
     it('should not log error when inviting user fails with 400 status', async () => {
@@ -194,9 +161,6 @@ describe('UsersSyncOnStartupService', () => {
       await service.sync();
 
       // Verify
-      expect(keycloakResourcesService.inviteUserToGroup).toHaveBeenCalledTimes(
-        2,
-      );
       expect(console.warn).not.toHaveBeenCalled(); // Should not log 400 errors
     });
   });

--- a/src/keycloak-sync-on-startup/keycloak-sync-on-startup/keycloak-sync-on-startup.service.ts
+++ b/src/keycloak-sync-on-startup/keycloak-sync-on-startup/keycloak-sync-on-startup.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { UsersService } from '../../users/infrastructure/users.service';
 import { KeycloakResourcesService } from '../../keycloak-resources/infrastructure/keycloak-resources.service';
 import { OrganizationsService } from '../../organizations/infrastructure/organizations.service';
-import { AuthContext } from '../../auth/auth-request';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
@@ -43,7 +42,7 @@ export class KeycloakSyncOnStartupService implements OnApplicationBootstrap {
         );
       }
     }
-    this.logger.log('Syncing users from DB to Keycloak');
+    /* this.logger.log('Syncing users from DB to Keycloak');
     const users = await this.usersService.find();
     for (const user of users) {
       await this.keycloakResourcesServices.createUser(user);
@@ -84,7 +83,7 @@ export class KeycloakSyncOnStartupService implements OnApplicationBootstrap {
           }
         }
       }
-    }
+    } */
     this.logger.log('Finished syncing users from Keycloak to database');
   }
 }


### PR DESCRIPTION
This pull request disables the synchronization process between the API database and Keycloak. The change ensures that no data will be synced to Keycloak automatically, allowing for better control over the data flow and minimizing unintended updates.

### Summary of Changes

- Removed logic for syncing data between the API database and Keycloak
- Ensured system dependencies are unaffected by this disablement

### Checklist

- [ ] Documentation updated, if applicable  
- [ ] Tests added or updated  
- [ ] Relevant issues linked, if applicable  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Disabled syncing users and organizations from the database to Keycloak; now only syncing users from Keycloak to the database.
  - Reduced related logs and error handling for database-to-Keycloak sync operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->