### PR TITLE
Set `_id` property for `templateDoc` and clean up spacing

### DIFF
--- a/src/marketplace/marketplace.service.ts
+++ b/src/marketplace/marketplace.service.ts
@@ -102,6 +102,7 @@ export class MarketplaceService {
 
     // Create a template document with validated data
     const templateDoc = new this.templateDoc(response.data.templateData);
+    templateDoc._id = response.data.id;
 
     await templateDoc.validate();
 

--- a/src/models/presentation/models.controller.ts
+++ b/src/models/presentation/models.controller.ts
@@ -84,6 +84,7 @@ export class ModelsController {
     }
 
     let template;
+
     if (createModelDto.templateId) {
       template = await this.templateService.findOneOrFail(
         createModelDto.templateId,


### PR DESCRIPTION
This pull request includes the following changes:
- Sets the `_id` property for `templateDoc` in `marketplace.service.ts`.
- Removes unused spacing in `models.controller.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected assignment of the template ID when creating new templates from the marketplace to ensure proper identification.

* **Style**
  * Improved code readability by adding a blank line in the template creation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->