### PR TITLE
feat: Update migrations for `ItemDoc` and `ModelDoc` to include schem…

### DIFF
--- a/src/items/infrastructure/item.schema.ts
+++ b/src/items/infrastructure/item.schema.ts
@@ -7,12 +7,13 @@ import {
 export enum ItemDocSchemaVersion {
   v1_0_0 = '1.0.0',
   v1_0_1 = '1.0.1',
+  v1_0_2 = '1.0.2',
 }
 
 @Schema({ collection: 'items', timestamps: true })
 export class ItemDoc extends PassportDoc {
   @Prop({
-    default: ItemDocSchemaVersion.v1_0_1,
+    default: ItemDocSchemaVersion.v1_0_2,
     enum: ItemDocSchemaVersion,
   }) // Track schema version
   _schemaVersion: ItemDocSchemaVersion;

--- a/src/items/infrastructure/items.service.ts
+++ b/src/items/infrastructure/items.service.ts
@@ -44,7 +44,7 @@ export class ItemsService {
       { _id: item.id },
       {
         $set: {
-          _schemaVersion: ItemDocSchemaVersion.v1_0_1,
+          _schemaVersion: ItemDocSchemaVersion.v1_0_2,
           modelId: item.modelId,
           templateId: item.templateId,
           ownedByOrganizationId: item.ownedByOrganizationId,

--- a/src/items/infrastructure/migrations.ts
+++ b/src/items/infrastructure/migrations.ts
@@ -1,13 +1,13 @@
-import { migratePassportDocToVersion_1_0_1 } from '../../product-passport/infrastructure/migrations';
+import { migratePassportDocToTemplateId } from '../../product-passport/infrastructure/migrations';
 import { ItemDoc, ItemDocSchemaVersion } from './item.schema';
 
-function migrateToVersion_1_0_1(itemDoc: ItemDoc) {
-  migratePassportDocToVersion_1_0_1(itemDoc);
-  itemDoc._schemaVersion = ItemDocSchemaVersion.v1_0_1;
+function migrateToVersion_1_0_2(itemDoc: ItemDoc) {
+  migratePassportDocToTemplateId(itemDoc);
+  itemDoc._schemaVersion = ItemDocSchemaVersion.v1_0_2;
 }
 
 export function migrateItemDoc(itemDoc: ItemDoc) {
-  if (itemDoc._schemaVersion === ItemDocSchemaVersion.v1_0_0) {
-    migrateToVersion_1_0_1(itemDoc);
+  if (itemDoc._schemaVersion === ItemDocSchemaVersion.v1_0_1) {
+    migrateToVersion_1_0_2(itemDoc);
   }
 }

--- a/src/models/infrastructure/migrations.ts
+++ b/src/models/infrastructure/migrations.ts
@@ -1,8 +1,8 @@
 import { ModelDoc, ModelDocSchemaVersion } from './model.schema';
-import { migratePassportDocToVersion_1_0_1 } from '../../product-passport/infrastructure/migrations';
+import { migratePassportDocToTemplateId } from '../../product-passport/infrastructure/migrations';
 
 function migrateToVersion_1_0_1(modelDoc: ModelDoc) {
-  migratePassportDocToVersion_1_0_1(modelDoc);
+  migratePassportDocToTemplateId(modelDoc);
   modelDoc._schemaVersion = ModelDocSchemaVersion.v1_0_1;
 }
 

--- a/src/product-passport/infrastructure/migrations.ts
+++ b/src/product-passport/infrastructure/migrations.ts
@@ -1,6 +1,6 @@
 import { PassportDoc } from './product-passport.schema';
 
-export function migratePassportDocToVersion_1_0_1(passportDoc: PassportDoc) {
+export function migratePassportDocToTemplateId(passportDoc: PassportDoc) {
   if (passportDoc.productDataModelId) {
     passportDoc.templateId = passportDoc.productDataModelId;
   }


### PR DESCRIPTION
…a version `v1.0.2`

Updated `ItemDoc` and `ModelDoc` migration logic to transition documents to schema version `v1.0.2`. Replaced `migratePassportDocToVersion_1_0_1` with `migratePassportDocToTemplateId` to support `templateId` migration. Adjusted default schema version and related property updates.